### PR TITLE
Updated version constraint to normalized form

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4"
+      version = ">= 4.0.0"
     }
   }
 }


### PR DESCRIPTION
Initializing the backend...
│ Error: failed to read dependency lock file: Invalid provider version constraints: The recorded version constraints for provider registry.terraform.io/hashicorp/aws must be written in normalized form: ">= 4.0.0".

This worked on version 1.0.6, however now it throws the above error. After changing the version manually to 4.0.0 it worked.